### PR TITLE
Fix deprecated onSceneGUIDelegate warning for Unity 2019.1 or newer

### DIFF
--- a/Assets/Editor/NormalPainterWindow.cs
+++ b/Assets/Editor/NormalPainterWindow.cs
@@ -35,12 +35,20 @@ namespace UTJ.NormalPainterEditor
         private void OnEnable()
         {
             isOpen = true;
+#if UNITY_2019_1_OR_NEWER
+            SceneView.duringSceneGui += OnSceneGUI;
+#else
             SceneView.onSceneGUIDelegate += OnSceneGUI;
+#endif
         }
 
         private void OnDisable()
         {
+#if UNITY_2019_1_OR_NEWER
+            SceneView.duringSceneGui += OnSceneGUI;
+#else
             SceneView.onSceneGUIDelegate -= OnSceneGUI;
+#endif
             isOpen = false;
         }
 


### PR DESCRIPTION
### Summary
Fixed warnings when using package via UPM with Unity 2019.1 or newer:
```
Packages\NormalPainter\Assets\Editor\NormalPainterWindow.cs(38,13): warning CS0618: 'SceneView.onSceneGUIDelegate' is obsolete: 'onSceneGUIDelegate has been deprecated. Use duringSceneGui instead.'
Packages\NormalPainter\Assets\Editor\NormalPainterWindow.cs(43,13): warning CS0618: 'SceneView.onSceneGUIDelegate' is obsolete: 'onSceneGUIDelegate has been deprecated. Use duringSceneGui instead.'
```

If needed, fine for me to open pull request to `dev` branch.

### Details
Unity made `onSceneGUIDelegate` obsolete in 2019.1, see https://github.com/Unity-Technologies/UnityCsReference/blob/2019.1/Editor/Mono/SceneView/SceneView.cs#L363. In 2018.4 it was not obsolete, see https://github.com/Unity-Technologies/UnityCsReference/blob/2018.4/Editor/Mono/SceneView/SceneView.cs#L253. Used Unity version define to support both versions.

### How to test
Install package via UPM using source branch and Unity 2018.4 and Unity 2019.1 and check normal painter editor window works:
```json
"com.utj.normalpainter": "https://github.com/rfadeev/NormalPainter.git#fix-onsceneguidelegate-warning",
```